### PR TITLE
Mythtv plugin requires tinyxml

### DIFF
--- a/media-plugins/xbmc-pvr-addons/xbmc-pvr-addons-9999.ebuild
+++ b/media-plugins/xbmc-pvr-addons/xbmc-pvr-addons-9999.ebuild
@@ -47,7 +47,7 @@ use pvrclient_nextpvr || sed -i "s:pvr.nextpvr::" addons/Makefile.am
 use pvrclient_njoy || sed -i "s:pvr.njoy::" addons/Makefile.am
 use pvrclient_vnsi || sed -i "s:pvr.vdr.vnsi::" addons/Makefile.am
 use pvrclient_vuplus || sed -i "s:pvr.vuplus::" addons/Makefile.am
-if ! use pvrclient_vuplus && ! use pvrclient_nextpvr && ! use pvrclient_njoy && ! use pvrclient_demo && ! use pvrclient_mediaportal; then
+if ! use pvrclient_vuplus && ! use pvrclient_nextpvr && ! use pvrclient_njoy && ! use pvrclient_demo && ! use pvrclient_mediaportal && ! use pvrclient_mythtv ; then
 sed -i "s: tinyxml::" lib/Makefile.am
 fi
 if ! use pvrclient_argustv; then


### PR DESCRIPTION
Hi, I need this fix to compile the mythtv plugin (If I understand correctly, tinyxml can not be disabled). Otherwise it will complain about missing tinyxml parts during compile =)
