### PR TITLE
Add pyyaml dependency

### DIFF
--- a/dev-util/fdroidserver/fdroidserver-9999.ebuild
+++ b/dev-util/fdroidserver/fdroidserver-9999.ebuild
@@ -19,5 +19,6 @@ KEYWORDS="~amd64"
 IUSE=""
 DEPEND="${PYTHON_DEPS}
 	dev-python/pyasn1-modules
+	dev-python/pyyaml
 	dev-python/paramiko"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
## Add pyyaml dependency.

Traceback (most recent call last):
  File "/usr/lib/python-exec/python2.7/fdroid", line 24, in <module>
    import fdroidserver.common
  File "/usr/lib64/python2.7/site-packages/fdroidserver/common.py", line 41, in <module>
    import metadata
  File "/usr/lib64/python2.7/site-packages/fdroidserver/metadata.py", line 29, in <module>
    import yaml
ImportError: No module named yaml
